### PR TITLE
修复 Waline 后缀格式未指定造成请求错误的 Bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,6 +70,7 @@ function artalk(nameList) {
  */
  function waline(nameList) {
   const result = {
+    type: 'png',
     icon: '亲亲',
     items: []
   }


### PR DESCRIPTION
修复 Waline 后缀格式未指定造成请求错误的 Bug，因为已经两周没更新，等不及了